### PR TITLE
Fixed display properties of nav bar links

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -7,12 +7,13 @@
   <!-- Right Navigation -->
   <div class="navbar-wagon-right hidden-xs hidden-sm">
 
-    <% if user_signed_in? %>
+     <%= link_to "Drive A Car", cars_path, class: "navbar-wagon-item navbar-wagon-link" %>
 
-      <!-- Links when logged in -->
-      <%= link_to "Your Bookings", mybookings_path, class: "navbar-wagon-item navbar-wagon-link" %>
-      <%= link_to "Drive A Car", cars_path, class: "navbar-wagon-item navbar-wagon-link" %>
+
       <%= link_to "Lease Your Car",new_car_path , class: "navbar-wagon-item navbar-wagon-link" %>
+
+    <% if user_signed_in? %>
+      <%= link_to "Your Bookings", mybookings_path, class: "navbar-wagon-item navbar-wagon-link" %>
 
       <!-- Avatar with dropdown menu -->
       <div class="navbar-wagon-item">


### PR DESCRIPTION
The correct links now display when logged in and out, user access still required to enter hire out car page